### PR TITLE
feat: Add weak reference and one-shot connection support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2024-12-21
+
+### Added
+- **Weak Reference Support**: Introduced `weak=True` for signal connections to allow automatic disconnection when the receiver is garbage-collected.
+- **One-Shot Connections**: Added `one_shot=True` in `connect(...)` to enable automatically disconnecting a slot after its first successful emission call.
+- Extended integration tests to cover new `weak` and `one_shot` functionality.
+
+### Improved
+- **Thread Safety**: Strengthened internal locking and concurrency patterns to reduce race conditions in high-load or multi-threaded environments.
+- **Documentation**: Updated `readme.md`, `api.md`, and example code sections to explain weak references, one-shot usage, and improved thread-safety details.
+
 ## [0.3.0] - 2024-12-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ TSignal is a lightweight, pure-Python signal/slot library that provides thread-s
 - **Flexible Connection Types**: Direct or queued connections, automatically chosen based on the caller and callee threads.
 - **Worker Thread Pattern**: Simplify background task execution with a built-in worker pattern that provides an event loop and task queue in a dedicated thread.
 - **Familiar Decorators**: Inspired by Qt’s pattern, `@t_with_signals`, `@t_signal`, and `@t_slot` let you define signals and slots declaratively.
+- **Weak Reference**: 
+  - By setting `weak=True` when connecting a slot, the library holds a weak reference to the receiver object. This allows the receiver to be garbage-collected if there are no other strong references to it. Once garbage-collected, the connection is automatically removed, preventing stale references.
 
 ## Why TSignal?
 
@@ -100,6 +102,7 @@ asyncio.run(main())
 ### Thread Safety and Connection Types
 TSignal automatically detects whether the signal emission and slot execution occur in the same thread or different threads:
 
+- **Auto Connection**: When connection_type is AUTO_CONNECTION (default), TSignal checks whether the slot is a coroutine function or whether the caller and callee share the same thread affinity. If they are the same thread and slot is synchronous, it uses direct connection. Otherwise, it uses queued connection.
 - **Direct Connection**: If signal and slot share the same thread affinity, the slot is invoked directly.
 - **Queued Connection**: If they differ, the call is queued to the slot’s thread/event loop, ensuring thread safety.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -126,10 +126,12 @@ Represents a signal. Signals are created by `@t_signal` and accessed as class at
 Connects the signal to a slot.
 
 - **Parameters:**
-  - receiver_or_slot: Either the receiver object and slot method, or just a callable (function/lambda) if slot is None.
-  - slot: The method in the receiver if a receiver object is provided.
-  - connection_type: DIRECT_CONNECTION, QUEUED_CONNECTION, or AUTO_CONNECTION.
-    - AUTO_CONNECTION (default): Determines connection type automatically based on thread affinity and slot type.
+  - **receiver_or_slot:** Either the receiver object and slot method, or just a callable (function/lambda) if slot is None.
+  - **slot:** The method in the receiver if a receiver object is provided.
+  - **connection_type:** DIRECT_CONNECTION, QUEUED_CONNECTION, or AUTO_CONNECTION.
+    - **AUTO_CONNECTION (default):** Determines connection type automatically based on thread affinity and slot type.
+  - **weak:** If `True`, the receiver is kept via a weak reference so it can be garbage collected once there are no strong references. The signal automatically removes the connection if the receiver is collected.
+  - **one_shot:** If `True`, the connection is automatically disconnected after the first successful emit call. This is useful for events that should only notify a slot once.
 
 **Examples:**
 
@@ -151,9 +153,29 @@ signal.connect(print)
 
 Disconnects a previously connected slot. Returns the number of disconnected connections.
 
+- **Parameters:**
+  - receiver: The object whose slot is connected. If receiver is None, all receivers are considered.
+  - slot: The specific slot to disconnect from the signal. If slot is None, all slots for the given receiver (or all connections if receiver is also None) are disconnected.
+- **Returns:** The number of connections that were disconnected.- 
+
+**Examples:**
+```python
+# Disconnect all connections
+signal.disconnect()
+
+# Disconnect all slots from a specific receiver
+signal.disconnect(receiver=my_receiver)
+
+# Disconnect a specific slot from a specific receiver
+signal.disconnect(receiver=my_receiver, slot=my_receiver.some_slot)
+
+# Disconnect a standalone function
+signal.disconnect(slot=my_function)
+```
+
 `emit(*args, **kwargs) -> None`
 
-Emits the signal, invoking all connected slots either directly or via the event loop of the slot’s associated thread.
+Emits the signal, invoking all connected slots either directly or via the event loop of the slot’s associated thread, depending on the connection type. If a connection is marked one_shot, it is automatically removed right after invocation.
 
 `TConnectionType`
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,7 +13,8 @@ tests/
 │   ├── test_property.py
 │   ├── test_signal.py
 │   ├── test_slot.py
-│   └── test_utils.py
+│   ├── test_utils.py
+│   └── test_weak.py
 ├── integration/        # Integration tests
 │   ├── __init__.py
 │   ├── test_async.py

--- a/examples/stock_monitor_simple.py
+++ b/examples/stock_monitor_simple.py
@@ -1,11 +1,16 @@
 # examples/stock_monitor_simple.py
 
-"""
-Stock monitor simple example.
-"""
-
 # pylint: disable=no-member
 # pylint: disable=unused-argument
+
+"""
+Stock monitor simple example.
+
+This module shows a straightforward example of using a worker (`DataWorker`)
+to generate data continuously and a display (`DataDisplay`) to process and
+log that data on the main thread. It's a minimal demonstration of TSignal's
+thread-safe signal/slot invocation.
+"""
 
 import asyncio
 import logging
@@ -20,7 +25,26 @@ logger = logger_setup(__name__, level=logging.DEBUG)
 
 @t_with_worker
 class DataWorker:
-    """Data worker"""
+    """
+    A simple data worker that emits incrementing integers every second.
+
+    Attributes
+    ----------
+    _running : bool
+        Indicates whether the update loop is active.
+    _update_task : asyncio.Task, optional
+        The asynchronous task that updates and emits data.
+
+    Signals
+    -------
+    data_processed
+        Emitted with the incremented integer each time data is processed.
+
+    Lifecycle
+    ---------
+    - `run(...)` is called automatically in the worker thread.
+    - `stop()` stops the worker, cancelling the update loop.
+    """
 
     def __init__(self):
         self._running = False
@@ -28,10 +52,18 @@ class DataWorker:
 
     @t_signal
     def data_processed(self):
-        """Signal emitted when data is processed"""
+        """
+        Signal emitted when data is processed.
+
+        Receives an integer count.
+        """
 
     async def run(self, *args, **kwargs):
-        """Worker initialization"""
+        """
+        Worker initialization and main event loop.
+
+        Creates the update loop task and waits until the worker is stopped.
+        """
 
         logger.info("[DataWorker][run] Starting")
 
@@ -51,7 +83,11 @@ class DataWorker:
                 pass
 
     async def update_loop(self):
-        """Update loop"""
+        """
+        Periodically emits a counter value.
+
+        Every second, the counter increments and `data_processed` is emitted.
+        """
 
         count = 0
 
@@ -66,7 +102,14 @@ class DataWorker:
 
 @t_with_signals
 class DataDisplay:
-    """Data display"""
+    """
+    A display class that receives the processed data from the worker.
+
+    Attributes
+    ----------
+    last_value : int or None
+        Stores the last received value from the worker.
+    """
 
     def __init__(self):
         self.last_value = None
@@ -74,7 +117,11 @@ class DataDisplay:
 
     @t_slot
     def on_data_processed(self, value):
-        """Slot called when data is processed"""
+        """
+        Slot called when data is processed.
+
+        Logs the received value and simulates a brief processing delay.
+        """
 
         current_thread = threading.current_thread()
         logger.debug(
@@ -87,7 +134,9 @@ class DataDisplay:
 
 
 async def main():
-    """Main function"""
+    """
+    Main function demonstrating how to set up and run the worker and display.
+    """
 
     logger.debug("[Main] Starting in thread: %s", threading.current_thread().name)
 

--- a/src/tsignal/__init__.py
+++ b/src/tsignal/__init__.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-module-docstring
+
 """
 TSignal - Python Signal/Slot Implementation
 """
@@ -23,5 +25,5 @@ __all__ = [
     "TConnectionType",
     "TSignalConstants",
     "t_signal_log_and_raise_error",
-    "t_signal_graceful_shutdown",    
+    "t_signal_graceful_shutdown",
 ]

--- a/src/tsignal/contrib/extensions/__init__.py
+++ b/src/tsignal/contrib/extensions/__init__.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-module-docstring
+
 from .property import t_property
 
 __all__ = ["t_property"]

--- a/src/tsignal/contrib/extensions/property.py
+++ b/src/tsignal/contrib/extensions/property.py
@@ -20,7 +20,66 @@ logger = logging.getLogger(__name__)
 
 class TProperty(property):
     """
-    A thread-safe property decorator.
+    A thread-safe property decorator for classes decorated with `@t_with_signals`
+    or `@t_with_worker`.
+
+    This property ensures that all reads (getter) and writes (setter) occur on the
+    object's designated event loop, maintaining thread-safety across different threads.
+
+    If the property is accessed from a different thread than the object's thread affinity:
+    - The operation is automatically dispatched (queued) onto the object's event loop
+      via `asyncio.run_coroutine_threadsafe`.
+    - This prevents race conditions that might otherwise occur if multiple threads
+      tried to read/write the same attribute.
+
+    Parameters
+    ----------
+    fget : callable, optional
+        The getter function for the property.
+    fset : callable, optional
+        The setter function for the property.
+    fdel : callable, optional
+        The deleter function for the property (not commonly used).
+    doc : str, optional
+        Docstring for this property.
+    notify : TSignal, optional
+        A signal to emit when the property value changes. If provided, the signal is
+        triggered after a successful write operation, and only if the new value is
+        different from the old value.
+
+    Notes
+    -----
+    - The property’s underlying storage is typically `_private_name` on the instance,
+      inferred from the property name (e.g. `value` -> `self._value`).
+    - If `notify` is set, `signal.emit(new_value)` is called whenever the property changes.
+    - Reading or writing this property from its "home" thread is done synchronously;
+      from any other thread, TSignal automatically queues the operation in the
+      object's event loop.
+
+    Example
+    -------
+    @t_with_signals
+    class Model:
+        @t_signal
+        def value_changed(self):
+            pass
+
+        @t_property(notify=value_changed)
+        def value(self):
+            return self._value
+
+        @value.setter
+        def value(self, new_val):
+            self._value = new_val
+
+    # Usage:
+    model = Model()
+    model.value = 10     # If called from a different thread, it’s queued to model's loop
+    current_val = model.value  # Also thread-safe read
+
+    See Also
+    --------
+    t_with_signals : Decorates a class to enable signal/slot features and thread affinity.
     """
 
     def __init__(self, fget=None, fset=None, fdel=None, doc=None, notify=None):
@@ -112,7 +171,36 @@ class TProperty(property):
 
 def t_property(notify=None):
     """
-    Decorator to create a thread-safe property.
+    Decorator to create a TProperty-based thread-safe property.
+
+    Parameters
+    ----------
+    notify : TSignal, optional
+        If provided, this signal is automatically emitted when the property's value changes.
+
+    Returns
+    -------
+    function
+        A decorator that converts a normal getter function into a TProperty-based property.
+
+    Example
+    -------
+    @t_with_signals
+    class Example:
+        @t_signal
+        def updated(self):
+            pass
+
+        @t_property(notify=updated)
+        def data(self):
+            return self._data
+
+        @data.setter
+        def data(self, value):
+            self._data = value
+
+    e = Example()
+    e.data = 42  # Thread-safe property set; emits 'updated' signal on change
     """
 
     def decorator(func):

--- a/src/tsignal/contrib/patterns/__init__.py
+++ b/src/tsignal/contrib/patterns/__init__.py
@@ -1,0 +1,1 @@
+# pylint: disable=missing-module-docstring

--- a/src/tsignal/contrib/patterns/worker/__init__.py
+++ b/src/tsignal/contrib/patterns/worker/__init__.py
@@ -1,0 +1,1 @@
+# pylint: disable=missing-module-docstring

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# pylint: disable=missing-module-docstring

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+# pylint: disable=missing-module-docstring

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -1,0 +1,141 @@
+# tests/integration/test_thread_safety.py
+
+# pylint: disable=unused-argument
+
+"""
+Test cases for thread safety of TSignal.
+"""
+
+import unittest
+import threading
+import gc
+from tsignal.core import t_with_signals, t_signal
+
+
+@t_with_signals
+class SafeSender:
+    """
+    A class that sends events.
+    """
+
+    @t_signal
+    def event(self, value):
+        """
+        Event signal.
+        """
+
+
+class SafeReceiver:
+    """
+    A class that receives events.
+    """
+
+    def __init__(self, name=None):
+        self.called = 0
+        self.name = name
+
+    def on_event(self, value):
+        """
+        Event handler.
+        """
+
+        self.called += 1
+
+
+class TestThreadSafe(unittest.IsolatedAsyncioTestCase):
+    """
+    Test cases for thread safety of TSignal.
+    """
+
+    async def test_thread_safety(self):
+        """
+        Test thread safety of TSignal.
+        """
+
+        sender = SafeSender()
+        receiver = SafeReceiver("strong_ref")
+
+        # regular connection
+        sender.event.connect(receiver, receiver.on_event, weak=False)
+
+        # weak reference connection
+        weak_receiver = SafeReceiver("weak_ref")
+        sender.event.connect(weak_receiver, weak_receiver.on_event, weak=True)
+
+        # additional receivers
+        extra_receivers = [SafeReceiver(f"extra_{i}") for i in range(10)]
+        for r in extra_receivers:
+            sender.event.connect(r, r.on_event, weak=False)
+
+        # background thread to emit events
+        def emit_task():
+            """
+            Background thread to emit events.
+            """
+
+            for i in range(1000):
+                sender.event.emit(i)
+
+        # thread to connect/disconnect repeatedly
+        def connect_disconnect_task():
+            """
+            Thread to connect/disconnect repeatedly.
+            """
+
+            # randomly connect/disconnect one of extra_receivers
+            for i in range(500):
+                idx = i % len(extra_receivers)
+                r = extra_receivers[idx]
+
+                if i % 2 == 0:
+                    sender.event.connect(r, r.on_event, weak=False)
+                else:
+                    sender.event.disconnect(r, r.on_event)
+
+        # thread to try to GC weak_receiver
+        def gc_task():
+            """
+            Thread to try to GC weak_receiver.
+            """
+
+            nonlocal weak_receiver
+            for i in range(100):
+                if i == 50:
+                    # release weak_receiver reference and try to GC
+                    del weak_receiver
+                    gc.collect()
+                else:
+                    # randomly emit events
+                    sender.event.emit(i)
+
+        threads = []
+        # multiple threads to perform various tasks
+        threads.append(threading.Thread(target=emit_task))
+        threads.append(threading.Thread(target=connect_disconnect_task))
+        threads.append(threading.Thread(target=gc_task))
+
+        # start threads
+        for t in threads:
+            t.start()
+
+        # wait for all threads to finish
+        for t in threads:
+            t.join()
+
+        # check: strong_ref receiver should have been called
+        self.assertTrue(
+            receiver.called > 0,
+            f"Strong ref receiver should have been called. Called={receiver.called}",
+        )
+
+        # some extra_receivers may have been connected/disconnected repeatedly
+        # if at least one of them has been called, it's normal
+        called_counts = [r.called for r in extra_receivers]
+        self.assertTrue(
+            any(c > 0 for c in called_counts),
+            "At least one extra receiver should have been called.",
+        )
+
+        # weak_receiver can be GCed. If it is GCed, the receiver will not be called anymore.
+        # weak_receiver itself is GCed, so it is not accessible. In this case, it is simply checked that it works without errors.
+        # Here, it is simply checked that the code does not raise an exception and terminates normally.

--- a/tests/integration/test_threading.py
+++ b/tests/integration/test_threading.py
@@ -1,11 +1,11 @@
 # tests/integration/test_threading.py
 
+# pylint: disable=unused-argument
+# pylint: disable=unnecessary-lambda
+
 """
 Test cases for threading.
 """
-
-# pylint: disable=unused-argument
-# pylint: disable=unnecessary-lambda
 
 import asyncio
 import threading

--- a/tests/integration/test_with_signal.py
+++ b/tests/integration/test_with_signal.py
@@ -1,5 +1,7 @@
 # tests/integration/test_with_signal.py
 
+# pylint: disable=duplicate-code
+
 """
 Test cases for the with-signal pattern.
 """

--- a/tests/integration/test_worker.py
+++ b/tests/integration/test_worker.py
@@ -1,12 +1,12 @@
 # tests/integration/test_worker.py
 
-"""
-Test cases for the worker pattern.
-"""
-
 # pylint: disable=no-member
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-variable
+
+"""
+Test cases for the worker pattern.
+"""
 
 import asyncio
 import logging

--- a/tests/integration/test_worker_queue.py
+++ b/tests/integration/test_worker_queue.py
@@ -1,11 +1,11 @@
 # tests/integration/test_worker_queue.py
 
+# pylint: disable=no-member
+# pylint: disable=redefined-outer-name
+
 """
 Test cases for the worker-queue pattern.
 """
-
-# pylint: disable=no-member
-# pylint: disable=redefined-outer-name
 
 import asyncio
 import logging

--- a/tests/integration/test_worker_signal.py
+++ b/tests/integration/test_worker_signal.py
@@ -1,13 +1,13 @@
 # tests/integration/test_worker_signal.py
 
-"""
-Test cases for the worker-signal pattern.
-"""
-
 # pylint: disable=redefined-outer-name
 # pylint: disable=unnecessary-lambda
 # pylint: disable=unnecessary-lambda-assignment
 # pylint: disable=no-member
+
+"""
+Test cases for the worker-signal pattern.
+"""
 
 import asyncio
 import logging

--- a/tests/performance/test_memory.py
+++ b/tests/performance/test_memory.py
@@ -1,12 +1,13 @@
 # tests/performance/test_memory.py
 
-"""
-Test cases for memory usage.
-"""
-
 # pylint: disable=no-member
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-variable
+
+
+"""
+Test cases for memory usage.
+"""
 
 import pytest
 from tsignal import t_with_signals, t_signal, t_slot

--- a/tests/performance/test_stress.py
+++ b/tests/performance/test_stress.py
@@ -1,12 +1,12 @@
 # tests/performance/test_stress.py
 
-"""
-Test cases for stress testing.
-"""
-
 # pylint: disable=no-member
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-variable
+
+"""
+Test cases for stress testing.
+"""
 
 import asyncio
 import logging

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,2 @@
+# pylint: disable=missing-module-docstring
+# pylint: disable=duplicate-code

--- a/tests/unit/test_property.py
+++ b/tests/unit/test_property.py
@@ -1,12 +1,12 @@
 # tests/unit/test_property.py
 
-"""
-Test cases for the property pattern.
-"""
-
 # pylint: disable=no-member
 # pylint: disable=unnecessary-lambda
 # pylint: disable=useless-with-lock
+
+"""
+Test cases for the property pattern.
+"""
 
 import asyncio
 import threading

--- a/tests/unit/test_slot.py
+++ b/tests/unit/test_slot.py
@@ -1,10 +1,11 @@
 # tests/unit/test_slot.py
 
+# pylint: disable=duplicate-code
+# pylint: disable=no-member
+
 """
 Test cases for the slot pattern.
 """
-
-# pylint: disable=no-member
 
 import asyncio
 import threading

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,10 +1,10 @@
 # tests/unit/test_utils.py
 
-"""Test utils"""
-
 # pylint: disable=no-member
 # pylint: disable=unused-argument
 # pylint: disable=redefined-outer-name
+
+"""Test utils"""
 
 from unittest.mock import MagicMock
 import logging

--- a/tests/unit/test_weak.py
+++ b/tests/unit/test_weak.py
@@ -1,0 +1,187 @@
+# tests/unit/test_weak.py
+
+"""
+Test cases for weak reference connections.
+"""
+
+# pylint: disable=unused-argument
+# pylint: disable=redundant-unittest-assert
+
+import unittest
+import gc
+import asyncio
+import weakref
+from tsignal.core import t_with_signals, t_signal
+
+
+class WeakRefReceiver:
+    """
+    A class that receives weak reference events.
+    """
+
+    def __init__(self):
+        self.called = False
+
+    def on_signal(self, value):
+        """
+        Event handler.
+        """
+
+        self.called = True
+        print(f"WeakRefReceiver got value: {value}")
+
+
+@t_with_signals(weak_default=True)
+class WeakRefSender:
+    """
+    A class that sends weak reference events.
+    """
+
+    @t_signal
+    def event(self):
+        """
+        Event signal.
+        """
+
+
+class StrongRefReceiver:
+    """
+    A class that receives strong reference events.
+    """
+
+    def __init__(self):
+        """
+        Initialize the receiver.
+        """
+
+        self.called = False
+
+    def on_signal(self, value):
+        """
+        Event handler.
+        """
+
+        self.called = True
+        print(f"StrongRefReceiver got value: {value}")
+
+
+@t_with_signals(weak_default=True)
+class MixedSender:
+    """
+    A class that sends mixed reference events.
+    """
+
+    @t_signal
+    def event(self, value):
+        """
+        Event signal.
+        """
+
+
+class TestWeakRefConnections(unittest.IsolatedAsyncioTestCase):
+    """
+    Test cases for weak reference connections.
+    """
+
+    async def test_weak_default_connection(self):
+        """
+        Test weak default connection.
+        """
+
+        sender = WeakRefSender()
+        receiver = WeakRefReceiver()
+
+        # connect without specifying weak, should use weak_default=True
+        sender.event.connect(receiver, receiver.on_signal)
+
+        sender.event.emit(42)
+        self.assertTrue(receiver.called, "Receiver should be called when alive")
+
+        # Delete receiver and force GC
+        del receiver
+        gc.collect()
+
+        # After GC, the connection should be removed automatically
+        # Emit again and ensure no error and no print from receiver
+        sender.event.emit(100)
+        # If receiver was alive or connection remained, it would print or set called to True
+        # But we no longer have access to receiver here
+        # Just ensure no exception - implicit check
+        self.assertTrue(
+            True, "No exception emitted, weak ref disconnected automatically"
+        )
+
+    async def test_override_weak_false(self):
+        """
+        Test override weak=False.
+        """
+
+        sender = MixedSender()
+        receiver = StrongRefReceiver()
+
+        # Even though weak_default=True, we explicitly set weak=False
+        sender.event.connect(receiver, receiver.on_signal, weak=False)
+
+        sender.event.emit(10)
+        self.assertTrue(receiver.called, "Receiver called with strong ref")
+
+        # Reset called
+        receiver.called = False
+
+        # Delete receiver and force GC
+        receiver_ref = weakref.ref(receiver)
+        del receiver
+        gc.collect()
+
+        # Check if receiver is GCed
+        # Originally: self.assertIsNone(receiver_ref(), "Receiver should be GCed")
+        # Update the expectation: Since weak=False means strong ref remains, receiver won't GC.
+        self.assertIsNotNone(
+            receiver_ref(), "Receiver should NOT be GCed due to strong ref"
+        )
+
+        # Emit again, should still have a reference
+        sender.event.emit(200)
+        # Even if we can't call receiver (it was del), the reference in slot keeps it alive,
+        # but possibly as an inaccessible object.
+        # Just checking no exception raised and that receiver_ref is not None.
+        # This confirms the slot strong reference scenario.
+        self.assertTrue(True, "No exception raised, strong ref scenario is consistent")
+
+    async def test_explicit_weak_true(self):
+        """
+        Test explicit weak=True.
+        """
+
+        sender = MixedSender()
+        receiver = StrongRefReceiver()
+
+        # weak_default=True anyway, but let's be explicit
+        sender.event.connect(receiver, receiver.on_signal, weak=True)
+
+        sender.event.emit(20)
+        self.assertTrue(receiver.called, "Explicit weak=True call")
+
+        receiver.called = False
+
+        # Create a weak reference to the receiver
+        receiver_ref = weakref.ref(receiver)
+        self.assertIsNotNone(receiver_ref(), "Receiver should be alive before deletion")
+
+        # Delete strong reference and force GC
+        del receiver
+        gc.collect()
+
+        # Check if the receiver has been collected
+        self.assertIsNone(
+            receiver_ref(), "Receiver should be GCed after weakref disconnection"
+        )
+
+        # Receiver gone, emit again
+        # Should not call anything, no crash
+        sender.event.emit(30)
+        self.assertTrue(True, "No exception and no call because weak disconnect")
+
+
+if __name__ == "__main__":
+    asyncio.run(unittest.main())


### PR DESCRIPTION
- Add weak reference support via weak=True in signal connections
- Add one-shot connections via one_shot=True that auto-disconnect after first emit
- Improve thread safety with internal connection locking
- Add extensive documentation for all public APIs
- Add new tests for weak references and one-shot functionality
- Update examples and documentation to demonstrate new features

This commit introduces two major features:
1. Weak reference support allows receivers to be garbage collected
2. One-shot connections automatically disconnect after first successful emit

The changes also include significant documentation improvements and additional test coverage.