### PR TITLE
Replace _tsignal_stopping.wait() with wait_for_stop()

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ class DataProcessor:
     async def run(self, *args, **kwargs):
         # The main entry point for the worker thread’s event loop
         # Wait for tasks or stopping signal
-        await self._tsignal_stopping.wait()
+        await self.wait_for_stop()
 
     async def process_data(self, data):
         # Perform heavy computation in the worker thread

--- a/docs/api.md
+++ b/docs/api.md
@@ -75,7 +75,7 @@ class Worker:
         # run is the main entry point in the worker thread
         print("Worker started with config:", config)
         # Wait until stop is requested
-        await self._tsignal_stopping.wait()
+        await self.wait_for_stop()
         self.finished.emit()
 
     async def do_work(self, data):
@@ -201,6 +201,7 @@ Slots can be async. When a signal with an async slot is emitted:
 - `run(*args, **kwargs)` defines the worker’s main logic.
 - `queue_task(coro)` schedules coroutines on the worker's event loop.
 - `stop()` requests a graceful shutdown, causing `run()` to end after `_tsignal_stopping` is triggered.
+- `wait_for_stop()` is a coroutine that waits for the worker to stop.
 
 **Signature Match for** ``run()``:
 
@@ -262,7 +263,7 @@ class BackgroundWorker:
 
     async def run(self):
         # Just wait until stopped
-        await self._tsignal_stopping.wait()
+        await self.wait_for_stop()
 
     async def heavy_task(self, data):
         await asyncio.sleep(2)  # Simulate heavy computation

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -269,7 +269,7 @@ class BackgroundWorker:
     async def run(self, *args, **kwargs):
         # The main entry point in the worker thread.
         # Wait until stopped
-        await self._tsignal_stopping.wait()
+        await self.wait_for_stop()
 
     async def heavy_task(self, data):
         await asyncio.sleep(2)  # Simulate heavy computation
@@ -292,7 +292,7 @@ If `run()` accepts additional parameters, simply provide them to `start()`:
 ```python
 async def run(self, config=None):
     # Use config here
-    await self._tsignal_stopping.wait()
+    await self.wait_for_stop()
 ```
 
 ```python

--- a/examples/stock_monitor_simple.py
+++ b/examples/stock_monitor_simple.py
@@ -70,7 +70,7 @@ class DataWorker:
         self._running = True
         self._update_task = asyncio.create_task(self.update_loop())
         # Wait until run() is finished
-        await self._tsignal_stopping.wait()
+        await self.wait_for_stop()
         # Clean up
         self._running = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tsignal"
-version = "0.4.3"
+version = "0.4.4"
 description = "A Python Signal-Slot library inspired by Qt"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/tsignal/contrib/extensions/property.py
+++ b/src/tsignal/contrib/extensions/property.py
@@ -93,6 +93,7 @@ class TProperty(property):
     def __get__(self, obj, objtype=None):
         if obj is None:
             return self
+
         if self.fget is None:
             raise AttributeError("unreadable attribute")
 
@@ -104,6 +105,7 @@ class TProperty(property):
             future = asyncio.run_coroutine_threadsafe(
                 self._get_value(obj), obj._tsignal_loop
             )
+
             return future.result()
         else:
             return self._get_value_sync(obj)
@@ -123,6 +125,7 @@ class TProperty(property):
             future = asyncio.run_coroutine_threadsafe(
                 self._set_value(obj, value), obj._tsignal_loop
             )
+
             # Wait for completion like slot direct calls
             return future.result()
         else:

--- a/src/tsignal/core.py
+++ b/src/tsignal/core.py
@@ -73,6 +73,7 @@ class TConnection:
 
         if self.is_weak and isinstance(self.receiver_ref, weakref.ref):
             return self.receiver_ref() is not None
+
         return True
 
     def get_slot_to_call(self):
@@ -126,10 +127,7 @@ def _wrap_standalone_function(func, is_coroutine):
                     ),
                 )
 
-            return func(*args, **kwargs)
-        else:
-            # Call sync function -> return result
-            return func(*args, **kwargs)
+        return func(*args, **kwargs)
 
     return wrap
 
@@ -303,12 +301,6 @@ class TSignal:
             )
             is_coro_slot = asyncio.iscoroutinefunction(maybe_slot)
 
-            is_coro_slot = asyncio.iscoroutinefunction(
-                receiver_or_slot.__func__
-                if hasattr(receiver_or_slot, "__self__")
-                else receiver_or_slot
-            )
-
             if is_bound_method:
                 obj = receiver_or_slot.__self__
 
@@ -394,6 +386,7 @@ class TSignal:
 
     def _cleanup_on_ref_dead(self, ref):
         """Cleanup connections on weak reference death."""
+
         # ref is a weak reference to the receiver
         # Remove connections associated with the dead receiver
         with self.connections_lock:
@@ -448,6 +441,7 @@ class TSignal:
                 # No receiver or slot specified, remove all connections.
                 count = len(self.connections)
                 self.connections.clear()
+
                 return count
 
             original_count = len(self.connections)
@@ -496,6 +490,7 @@ class TSignal:
                 "[TSignal][disconnect][END] disconnected: %s",
                 disconnected,
             )
+
             return disconnected
 
     def emit(self, *args, **kwargs):
@@ -726,6 +721,7 @@ def t_signal(func):
 
         if not hasattr(self, f"_{sig_name}"):
             setattr(self, f"_{sig_name}", TSignal())
+
         return getattr(self, f"_{sig_name}")
 
     return TSignalProperty(wrap, sig_name)
@@ -814,6 +810,7 @@ def t_slot(func):
                     future = asyncio.run_coroutine_threadsafe(
                         func(self, *args, **kwargs), self._tsignal_loop
                     )
+
                     return await asyncio.wrap_future(future)
 
             return await func(self, *args, **kwargs)
@@ -853,6 +850,7 @@ def t_slot(func):
                             future.set_exception(e)
 
                     self._tsignal_loop.call_soon_threadsafe(callback)
+
                     return future.result()
 
             return func(self, *args, **kwargs)
@@ -938,6 +936,7 @@ def t_with_signals(cls=None, *, loop=None, weak_default=True):
             original_init(self, *args, **kwargs)
 
         cls.__init__ = __init__
+
         return cls
 
     if cls is None:


### PR DESCRIPTION
- Introduced new wait_for_stop() method in WorkerClass for better encapsulation
- Updated all direct calls to _tsignal_stopping.wait() to use wait_for_stop()
- Updated documentation to reflect the new method
- Added code formatting improvements and whitespace cleanup